### PR TITLE
Start oscillator after user gesture

### DIFF
--- a/sketch/sketch.js
+++ b/sketch/sketch.js
@@ -130,6 +130,7 @@ function setStepDraw() {
 			oscillator.freq(frequnecy);
 
 			if(soundButton.clicked === "true"){
+					oscillator.start();	
 					envelope.play();
 			}
 
@@ -211,8 +212,7 @@ function setSound(attackTime, decayTime, susRatio, releaseTime,
 	oscillator = new p5.Oscillator();
 	oscillator.setType("sine");
 	oscillator.amp(envelope);
-	oscillator.start();
-
+	
 	return [oscillator, envelope];
 };
 


### PR DESCRIPTION
Hi @xeniasuper !

I found about this project coming from [ncase's blog](https://blog.ncase.me/the-explorables-jam/), and I saw that the sound wasn't working properly, at least not on Firefox and Brave.

On the console log of your site I got a `An AudioContext was prevented from starting automatically. It must be created or resumed after a user gesture on the page`. My best guess is that since the last commit to this repo, which is now a few years old, there were some changes on when a website is allowed to play sound. 

I modified just one line of code so that the button click is the one that calls the `.start()`, making the audio work once again.